### PR TITLE
Shulker soul packing + chorium case tweaks

### DIFF
--- a/datapacks/TurtleRealm/data/minecraft/loot_table/entities/shulker.json
+++ b/datapacks/TurtleRealm/data/minecraft/loot_table/entities/shulker.json
@@ -6,7 +6,11 @@
       "functions": [
         {
           "function": "minecraft:set_count",
-          "count": 2
+          "count": {
+            "type": "minecraft:uniform",
+            "min": 0,
+            "max": 2
+          }
         }
       ],
       "conditions": [],

--- a/scripts/customItems/items/chorium_case.sk
+++ b/scripts/customItems/items/chorium_case.sk
@@ -2,6 +2,7 @@
 options:
     maxAmount: 6400
     maxDistance: 30
+    maxDistanceSneaking: 15
 
 when ready to load recipes:
     register smithing transform recipe:
@@ -22,15 +23,19 @@ local function updateCase(case:item) :: item:
         set string tag "customId" of (custom nbt of {_case}) to "turtle:chorium_case_filled"
     return {_case}
 
+# show tp indicator
+on player tick:
+    getId(player's tool) is "turtle:chorium_case_filled"
+    set {_dist} to ({@maxDistanceSneaking} if player is sneaking else {@maxDistance})
+    set {_ray} to raytrace from player with max distance {_dist} while ignoring passable blocks
+    set {_hit} to (hit location of {_ray}) ? (location {_dist} blocks in front of player's head)
+    make 1 of witch at {_hit} for player
+
 # teleport
 on right click:
     # setup/checks
-    if event.getHand() is off_hand_slot:
-        set {_tool} to player's offhand tool
-    else:
-        set {_tool} to player's tool
-    getId({_tool}) is "turtle:chorium_case_filled"
-    player.hasCooldown(1 of {_tool}) is false
+    getId(player's tool) is "turtle:chorium_case_filled"
+    player.hasCooldown(1 of player's tool) is false
     cancel event
     ###
     # shoot pearl
@@ -38,8 +43,9 @@ on right click:
     play sound "minecraft:entity.ender_pearl.throw" in neutral category with volume 0.5 and pitch 0.4 at player
     ###
     # teleport
-    set {_ray} to raytrace from player with max distance {@maxDistance} with ray size 1 while ignoring passable blocks
-    set {_hit} to (hit location of {_ray}) ? (location {@maxDistance} blocks in front of player)
+    set {_dist} to ({@maxDistanceSneaking} if player is sneaking else {@maxDistance})
+    set {_ray} to raytrace from player with max distance {_dist} while ignoring passable blocks
+    set {_hit} to (hit location of {_ray}) ? (location {_dist} blocks in front of player's head)
     set {_startLoc} to (player's location)
     relative tp player to {_hit}
     set fall distance of player to 0
@@ -54,22 +60,17 @@ on right click:
         set {_loc} to ({_loc} ~ {_v})
     play sound "minecraft:entity.player.teleport" in player category at player
     # cooldown / swing
-    player.setCooldown(1 of {_tool}, floor(20*(float tag "minecraft:use_cooldown;seconds" of nbt of {_tool})))
+    player.setCooldown(1 of player's tool, floor(20*(float tag "minecraft:use_cooldown;seconds" of nbt of player's tool)))
     if event.getHand() is off_hand_slot:
         make player swing their offhand
     else:
         make player swing their hand
     # lower count
     player's gamemode isn't creative
-    set {_amount} to ((int tag "storedPearls" of custom nbt of {_tool}) ? 1)
+    set {_amount} to ((int tag "storedPearls" of custom nbt of player's tool) ? 1)
     set {_newamount} to {_amount} - 1
-    set (int tag "storedPearls" of (custom nbt of {_tool})) to {_newamount}
-    set {_tool} to updateCase({_tool})
-    # update tool and swing hand
-    if event.getHand() is off_hand_slot:
-        set player's offhand tool to ({_tool} ? player's tool)
-    else:
-        set player's tool to ({_tool} ? player's tool)
+    set (int tag "storedPearls" of (custom nbt of player's tool)) to {_newamount}
+    set player's tool to updateCase(player's tool)
 
 # insert/extract pearls
 on inventory click:

--- a/scripts/customItems/yamls/shulkers.yml
+++ b/scripts/customItems/yamls/shulkers.yml
@@ -4,6 +4,7 @@ turtle:
       base: phantom_membrane
       name: "Shulker Soul"
       model: "turtle:shulker_soul"
+      max_stack_size: 16
     shulker_shell_red:
       base: shulker_shell
       name: "Red Shulker Shell"

--- a/scripts/tweaks/items/shulker_shell.sk
+++ b/scripts/tweaks/items/shulker_shell.sk
@@ -1,14 +1,38 @@
 
-# chest packing
+# packing
 on right click:
-    event-block is chest
-    player's tool is shulker shell
-    player's offhand tool is shulker shell
-    getId(player's tool) is getId(player's offhand tool)
-    cancel event
-    set {_col} to (dye color str of (dye color of player's tool)) ? ""
-    set {_shulker} to ("%{_col}% shulker box" parsed as itemtype)
-    set block only of event-block to {_shulker}
-    set blockdata tag "facing" of (block at event-block) to "up"
-    play sound "minecraft:entity.shulker.close" in player category at event-block
-    make 10 of poof at event-block with extra 0.2
+    # shulker soul
+    set {_e} to target entity of player
+    set {_dist} to (distance between player's head and {_e})
+    set {_attr} to (player entity interaction range final attribute of player)
+    set {_e} to {_e} if ({_dist} < {_attr}) else {_}
+    if getId(item of {_e}) is "turtle:shulker_soul":
+        (item amount of item of {_e}) is 1
+        player's tool is shulker shell
+        player's offhand tool is shulker shell
+        getId(player's tool) is getId(player's offhand tool)
+        cancel event
+        kill entity within {_e}
+        if player's gamemode isn't creative:
+            remove (1 of player's tool) from (player's tool)
+            remove (1 of player's offhand tool) from (player's offhand tool)
+        set {_col} to (dye color of player's tool) ? ""
+        spawn shulker at {_e}:
+            set color of event-entity to {_col}
+            play sound "minecraft:item.bottle.fill_dragonbreath" in player category at (event-entity's location)
+            make 10 of poof at event-entity with extra 0.2
+    # chest
+    else if event-block is chest:
+        player's tool is shulker shell
+        player's offhand tool is shulker shell
+        getId(player's tool) is getId(player's offhand tool)
+        cancel event
+        if player's gamemode isn't creative:
+            remove (1 of player's tool) from (player's tool)
+            remove (1 of player's offhand tool) from (player's offhand tool)
+        set {_col} to (dye color str of (dye color of player's tool)) ? ""
+        set {_shulker} to ("%{_col}% shulker box" parsed as itemtype)
+        set block only of event-block to {_shulker}
+        set blockdata tag "facing" of (block at event-block) to "up"
+        play sound "minecraft:item.bottle.fill_dragonbreath" in player category at event-block
+        make 10 of poof at event-block with extra 0.2


### PR DESCRIPTION
- Shulker soul packing into live shulkers
- Shulker souls now only stack to 16
- Nerf shulker shell drop rate
- Chorium case shows particle indicator to where it will tp
- Chorium case no longer works in offhand (was bugged anyway)
- Slightly changed logic for chorium case choosing where to tp to