### PR TITLE
Fix/improve protected items

### DIFF
--- a/scripts/enchanting/enchantments/soulbound.sk
+++ b/scripts/enchanting/enchantments/soulbound.sk
@@ -1,12 +1,4 @@
 
-on death of player:
-    set {_e} to enchantment from key "turtle:soulbound"
-    gamerule keepInventory of victim's world is false
-    loop drops:
-        loop-value is enchanted with {_e}
-        remove loop-value from drops
-        event.getItemsToKeep().add(loop-value)
-
 on drop:
     player isn't sneaking
     set {_e} to enchantment from key "turtle:soulbound"

--- a/scripts/player.sk
+++ b/scripts/player.sk
@@ -49,19 +49,23 @@ on player tick:
     # tablist
     updateTablist(player)
 
+# handle player death
 on death of player:
-    # drop skull
-    if {enabledFeatures::dropskull} is true:
-        attacker is player
-        set {_head} to nbt skull of "%victim%"
-        drop {_head} at victim's location
-        {enabledFeatures::protectdeathloot} is true
-        protectItem(last dropped item)
-    
-    # protected items
-    if {enabledFeatures::protectdeathloot} is true:
-        set {_loc} to head location of victim
-        wait 1 tick
-        loop all dropped items in radius 2 of {_loc}:
-            short tag "Age" of full nbt of loop-value is 0
-            protectItem(loop-value)
+    set {_e} to enchantment from key "turtle:soulbound"
+    if event.getKeepInventory() is false:
+        set {_drops::*} to ...event.getDrops()
+        event.getDrops().clear()
+        # drop skull
+        if {enabledFeatures::dropskull} is true:
+            attacker is a player
+            add (nbt skull of "%victim%").getRandom() to {_drops::*}
+        loop {_drops::*}:
+            # soulbound
+            if loop-value is enchanted with {_e}:
+                event.getItemsToKeep().add(loop-value)
+            # protected items
+            else:
+                if {enabledFeatures::protectdeathloot} is true:
+                    event.getDrops().add(protectItemStack(loop-value))
+                else:
+                    event.getDrops().add(loop-value)

--- a/scripts/tweaks/items/protected-items.sk
+++ b/scripts/tweaks/items/protected-items.sk
@@ -5,6 +5,11 @@ on load:
     set {-features::protecteditems::warn} to "When disabled, previously protected items will stay protected"
     set {-features::protecteditems::icon} to glowstone dust
 
+function protectItemStack(item:item) :: item:
+    {enabledFeatures::protecteditems} is true
+    set boolean tag "protectedItem" of custom nbt of {_item} to true
+    return {_item}
+
 function protectItem(e:entity):
     {enabledFeatures::protecteditems} is true
     {_e} is a dropped item
@@ -19,6 +24,12 @@ function isProtectedItem(e:entity) :: boolean:
         return true
     else:
         return false
+
+# convert protected itemstacks to protected items
+on spawn of dropped item:
+    (boolean tag "Item;components;minecraft:custom_data;protectedItem" of (nbt of event-entity)) is true
+    delete (boolean tag "Item;components;minecraft:custom_data;protectedItem" of (nbt of event-entity))
+    protectItem(event-entity)
 
 # handle protected items
 


### PR DESCRIPTION
- Move all player death code to one place
- Directly get death drops from event instead of guessing
- Itemstacks can be protected, which just means they will be protected when they are spawned into the world as a dropped item
- Small problem where damage:0 nbt tag is added to items it shouldn't exist on, just makes the items unstackable