### PR TITLE
Fix death drops nbt, fix voidwrap velocity

### DIFF
--- a/scripts/customItems/code/customItemUpdating.sk
+++ b/scripts/customItems/code/customItemUpdating.sk
@@ -10,6 +10,9 @@ options:
 function updateItem(item:item) :: item:
     set {_id} to getId({_item})
     set {_rawitem} to getItem({_id}) ? {_item}
+    if int tag "minecraft:damage" of nbt of {_item} is 0:
+        int tag "minecraft:damage" of vanilla nbt of {_rawitem} isn't set
+        delete int tag "minecraft:damage" of nbt of {_item}
     if nbt of {_item} is nbt of {_rawitem}:
         return {_item}
     set {_newitem} to (item amount of {_item}) of (type of {_rawitem})

--- a/scripts/tweaks/environment/voidwrap.sk
+++ b/scripts/tweaks/environment/voidwrap.sk
@@ -27,15 +27,19 @@ on damage:
     cancel event
     (environment of event-world) is end
     warp(victim, {@overworld}, {@upWrapY})
-    loop 3 times:
+    while (y-coord of victim) > ({@upWrapY}-10):
         push victim down with force 0.25
         wait 1 tick
+        if loop-iteration > 100:
+            exit loop
 
 on player tick:
     (y-coord of player) > ({@upWrapY}+5)
     {dragonDefeated} is true
     (world of player) is {@overworld}
     warp(player, {@endWorld}, -59)
-    loop 3 times:
-        push player up with force 0.5
+    while (y-coord of player) < -49:
+        push player up with force 0.1
         wait 1 tick
+        if loop-iteration > 100:
+            exit loop


### PR DESCRIPTION
- Death drops (and other things) will not set damage:0 nbt if vanilla item doesn't have it
- Void wrap will push player up/down while player's y is above/below 10 blocks of tp location (or until 10s). This means you will never immediately fall back down after flying up to the end