### PR TITLE
Update commands + chat player names

### DIFF
--- a/config.sk
+++ b/config.sk
@@ -76,7 +76,7 @@ allow ops to use effect commands: true
 # Whether server operators which do not have the permission "skript.effectcommands" should have access to effect commands.
 # This setting is mainly useful for servers that do not run any permissions plugin.
 
-log effect commands: false
+log effect commands: true
 # Whether Skript should log the usage of effect commands.
 # They will be logged as [INFORMATION] in this format: '<player> issued effect command: <command>'
 

--- a/scripts/_utils/game/color.sk
+++ b/scripts/_utils/game/color.sk
@@ -55,3 +55,38 @@ expression:
         set {_return2} to (dark gray if {_return2} is "gray" else ({_return2} parsed as color))
         set {_return3} to (dark gray if {_return3} is "gray" else ({_return3} parsed as color))
         return {_return1} ? {_return2} ? {_return3}
+
+# Ping color
+# Get a color based on the ping value
+# Based on functionality from Better Ping Display mod
+expression:
+    patterns:
+        ping color (of|from) %integer%
+        %integer%'s ping color
+    get:
+        set {_ping} to expr-1
+        set {_PING_START} to 0
+        set {_PING_MID} to 150
+        set {_PING_END} to 300
+
+        set {_COLOR_GREY} to rgb(83, 83, 83)
+        set {_COLOR_START} to rgb(0, 230, 118)
+        set {_COLOR_MID} to rgb(214, 205, 48)
+        set {_COLOR_END} to rgb(229, 57, 53)
+
+        if ({_ping} < {_PING_START}):
+            return {_COLOR_GREY}
+        else if ({_ping} < {_PING_MID}):
+            return interpolate({_COLOR_START}, {_COLOR_MID}, computeOffset({_PING_START}, {_PING_MID}, {_ping}))
+        else:
+            return interpolate({_COLOR_MID}, {_COLOR_END}, computeOffset({_PING_MID}, {_PING_END}, min({_ping}, {_PING_END})))
+
+local function computeOffset(start:integer, end:integer, value:integer) :: number:
+    set {_offset} to ({_value}-{_start}) / ({_end}-{_start})
+    return max(0, min(1, {_offset}))
+
+local function interpolate(color1:color, color2:color, offset:number) :: color:
+    set {_r} to ({_color1}.getRed() + ({_color2}.getRed() - {_color1}.getRed()) * {_offset})
+    set {_g} to ({_color1}.getGreen() + ({_color2}.getGreen() - {_color1}.getGreen()) * {_offset})
+    set {_b} to ({_color1}.getBlue() + ({_color2}.getBlue() - {_color1}.getBlue()) * {_offset})
+    return rgb({_r}, {_g}, {_b})

--- a/scripts/_utils/utils/info.sk
+++ b/scripts/_utils/utils/info.sk
@@ -1,0 +1,21 @@
+
+local function playerInfo(p:player) :: string:
+    if (time played of {_p}) is set:
+        add "Playtime: §6%hours of time played of {_p}%h" to {_lines::*}
+    if {discordLinks::%uuid of {_p}%} is set:
+        set {_user} to user with id {discordLinks::%uuid of {_p}%}
+        if {_user} is set:
+            add "Discord: §9%{_user}% §7(@%discord name of {_user}%)" to {_lines::*}
+        else:
+            add "Discord: §cUnknown User%nl%§7@???" to {_lines::*}
+    else:
+        add "Discord: §cNot linked" to {_lines::*}
+    if (uuid of {_p}) is set:
+        add "§8%uuid of {_p}%" to {_lines::*}
+    return (join {_lines::*} with "§r%nl%")
+
+function playerComponent(p:offline player) :: object:
+    set {_c} to text component from ({_p}'s display name)
+    set hover event of {_c} to (hover event showing (playerInfo({_p})))
+    set click event of {_c} to (click event to suggest command "/msg %{_p}%")
+    return {_c}

--- a/scripts/chat/chat.sk
+++ b/scripts/chat/chat.sk
@@ -27,12 +27,20 @@ on load:
 
 on join:
     {enabledFeatures::joinleavemsgs} is true
-    set join message to "§a+ §7| &f%player% joined the game"
+    set {_c::1} to "§a+ §7| "
+    set {_c::2} to playerComponent(player)
+    set {_c::3} to " joined the game"
+    clear join message
+    broadcast components (merge components {_c::*})
     discordSend("**+** %player%")
 
 on leave:
     {enabledFeatures::joinleavemsgs} is true
-    set leave message to "§c- §7| &f%player% left the game"
+    set {_c::1} to "§c- §7| "
+    set {_c::2} to playerComponent(player)
+    set {_c::3} to " left the game"
+    clear leave message
+    broadcast components (merge components {_c::*})
     discordSend("**-** %player%")
 
 on death of player:
@@ -48,7 +56,8 @@ on async chat:
     # create format
     # {_msg} is used for discord
     set {_p} to player
-    set {_c::1} to text component from "§7%display name of {_p}%"
+    set {_c::1} to playerComponent({_p})
+    set color format of {_c::1} to light gray
     set {_c::2} to text component from "§7: &r"
     set {_c::3} to colored async chat message
     set click event of {_c::1} to click event to suggest command "/msg %name of {_p}% "

--- a/scripts/chat/commands/heal.sk
+++ b/scripts/chat/commands/heal.sk
@@ -1,23 +1,16 @@
 
-command /heal [<string>]:
+brig command /turtle:heal:
     permission: op
-    permission message: §cYou don't have permission!
+    arguments:
+        register optional entities arg "entities"
     trigger:
         {enabledFeatures::commands} is true
-        if arg-1 is set:
-            set {_p} to arg-1 parsed as player
+        set {_entities::*} to ({_entities::*} ? player)
+        loop {_entities::*}:
+            heal loop-value
+            feed loop-value
+            set saturation of loop-value to 20
+        if size of {_entities::*} is 1:
+            send "Healed %name of first element of {_entities::*}%"
         else:
-            set {_p} to player
-        if {_p} isn't set:
-            send "§cNo player was found for '%arg-1%'"
-            exit
-        heal {_p}
-        feed {_p}
-        set saturation of {_p} to 20
-        if player is {_p}:
-            send "§7Healed!" to player
-        else:
-            send "§7Healed §6%{_p}%§7!" to player
-
-on tab complete of "/heal", "/skript:heal":
-    set tab completions for position 1 to all players
+            send "Healed %size of {_entities::*}% entities"

--- a/scripts/chat/commands/ping.sk
+++ b/scripts/chat/commands/ping.sk
@@ -1,25 +1,22 @@
 
 on load:
     set {-features::commands::name} to "Commands"
-    set {-features::commands::desc} to "Simple but useful commands\n/ping /heal /repair"
+    set {-features::commands::desc} to "Simple but useful commands\nType '/turtle:' to show tab-completion for all commands"
     set {-features::commands::warn} to "If disabled, commands will still be visible but not do anything"
     set {-features::commands::icon} to command block
 
-command /ping [<string>]:
+brig command /turtle:ping:
+    arguments:
+        register optional player arg "players"
     trigger:
         {enabledFeatures::commands} is true
-        if arg-1 is set:
-            set {_p} to arg-1 parsed as player
+        set {_player} to ({_player} ? player)
+        set {_ping} to ({_player}'s ping)
+        if {_player} is player:
+            set {_c::2} to (text component from "Your ping is ")
         else:
-            set {_p} to player
-        if {_p} isn't set:
-            send "§cNo player was found for '%arg-1%'"
-            exit
-        if {_p} is player:
-            send "§7Your ping is §3%{_p}'s ping%ms"
-        else:
-            send "§7%{_p}%'s ping is §3%{_p}'s ping%ms"
-
-on tab complete of "/ping", "/skript:ping":
-	set tab completions for position 1 to all players
-			
+            set {_c::1} to playerComponent({_player})
+            set {_c::2} to (text component from "'s ping is ")
+        set {_c::2} to (text component from "%{_ping}%ms")
+        set color format of {_c::2} to (ping color of {_ping})
+        send component (merge components {_c::*})

--- a/scripts/chat/commands/repair.sk
+++ b/scripts/chat/commands/repair.sk
@@ -1,24 +1,15 @@
 
-command /repair [<string>]:
+brig command /turtle:repair:
     permission: op
-    permission message: §cYou don't have permission!
+    arguments:
+        register optional entities arg "entities"
     trigger:
         {enabledFeatures::commands} is true
-        if arg-1 is set:
-            set {_p} to arg-1 parsed as player
+        set {_entities::*} to ({_entities::*} ? player)
+        loop {_entities::*}:
+            (max durability of (loop-value's tool)) isn't 0
+            repair (loop-value's tool)
+        if size of {_entities::*} is 1:
+            send "Repaired tool of %name of first element of {_entities::*}%"
         else:
-            set {_p} to player
-        if {_p} isn't set:
-            send "§cNo player was found for '%arg-1%'"
-            exit
-        if max durability of {_p}'s tool is 0:
-            send "§c%type of {_p}'s tool% does not have durability!" to player
-            stop
-        repair {_p}'s tool
-        if player is {_p}:
-            send "§7Repaired your §3%type of {_p}'s tool%§7!" to player
-        else:
-            send "§7Repaired §6%{_p}%§7's §3%type of {_p}'s tool%§7!" to player
-
-on tab complete of "/repair", "/skript:repair":
-    set tab completions for position 1 to all players		
+            send "Repaired tool of %size of {_entities::*}% entities"

--- a/scripts/chat/discord.sk
+++ b/scripts/chat/discord.sk
@@ -71,7 +71,7 @@ local function createLinkCode() :: string:
     return {_code}
 
 # /discord
-brig command tree /discord:
+brig command tree /turtle:discord:
     #trigger:
     #    send "§9join link"
     literal arg "link":

--- a/scripts/customItems/code/customItemLoader.sk
+++ b/scripts/customItems/code/customItemLoader.sk
@@ -1,8 +1,4 @@
 
-# Made for 1.21.4
-
-using item_component
-
 import:
     java.lang.Integer as javaInteger
     java.lang.Float as javaFloat

--- a/scripts/customItems/code/customItemUpdating.sk
+++ b/scripts/customItems/code/customItemUpdating.sk
@@ -86,6 +86,7 @@ on chunk load:
 on join:
     loop (amount of slots of player's inventory) times:
         set {_item} to (slot (loop-value)-1 of player's inventory)
+        {_item} is set
         updateItemSlot({_item}, player's inventory, (loop-value)-1, "player join")
 
 # /give etc

--- a/scripts/customItems/items/mob_bundle.sk
+++ b/scripts/customItems/items/mob_bundle.sk
@@ -1,6 +1,4 @@
 
-using item_component
-
 options:
     # Mobs that can be picked up by mob bundle
     AllowedMobs: allay, armadillo, bat, bee, cat, "chicken" parsed as entity type, cow, dolphin, fox, frog, goat, mooshroom, ocelot, panda, parrot, pig, polar bear, "rabbit" parsed as entity type, sheep, strider, villager, wolf

--- a/scripts/enchanting/anvil.sk
+++ b/scripts/enchanting/anvil.sk
@@ -1,6 +1,4 @@
 
-using item_component
-
 on load:
     set {-features::anvil::name} to "Anvil cost/renaming"
     set {-features::anvil::desc} to "Item repair costs do not build up,\nand item renaming is free and can be colored"


### PR DESCRIPTION
- Custom command outputs now mimic vanilla format
- /ping colors ping just like [Better Ping Display](<https://www.curseforge.com/minecraft/mc-mods/better-ping-display>) mod
- Hover over a player's name in some messages to see stats like playtime and linked discord account
- Change `/minecraft:discord` to `/turtle:discord`
- Fix warnings in console when joining game with empty armor slots
- Remove `using item_component` (removed from SkBee)
- Enable 'log effect commands' in Skript config