### PR TITLE
Re-add /catfact and chorium elytra improvements

### DIFF
--- a/scripts/_utils/utils/json.sk
+++ b/scripts/_utils/utils/json.sk
@@ -1,0 +1,7 @@
+
+import:
+    com.google.gson.JsonParser
+
+function valueFromJson(json:string, key:string) :: object:
+    set {_jsonObject} to JsonParser.parseString({_json}).getAsJsonObject()
+    return {_jsonObject}.get({_key}).getAsString()

--- a/scripts/chat/commands/catfact.sk
+++ b/scripts/chat/commands/catfact.sk
@@ -1,4 +1,4 @@
-###
+
 import:
     java.lang.StringBuffer
     java.io.InputStreamReader
@@ -9,29 +9,8 @@ import:
 command /catfact:
     trigger:
         async run 0 ticks later:
-            set {_url} to new URL("https://catfact.ninja/fact")
-            set {_con} to {_url}.openConnection()
-            {_con}.setRequestMethod("GET")
-            {_con}.setRequestProperty("User-Agent", "Skript/Reflect")
-            {_con}.setConnectTimeout(1000)
-            {_con}.setReadTimeout(1000)
-            set {_responseCode} to {_con}.getResponseCode()
-            if ({_responseCode} is HttpURLConnection.HTTP_OK):
-                set {_stream} to {_con}.getInputStream()
-                set {_reader} to new InputStreamReader({_stream})
-                set {_buffer} to new BufferedReader({_reader})
-                set {_line} to {_buffer}.readLine()
-                while {_line} is set:
-                    add {_line} to {_response::*}
-                    set {_line} to {_buffer}.readLine()
-                {_buffer}.close()
-                {_reader}.close()
-                set {_response} to first element of {_response::*}
-                replace """fact""" with "fact" in {_response}
-                replace """length""" with "length" in {_response}
-                set {_fact} to string tag "fact" of nbt compound from {_response}
-                broadcast " &3🐈 Cat Fact: &7%{_fact}%"
-            else:
-                broadcast {_con}.getErrorStream()
-            {_con}.disconnect()
-###
+            set {_json} to (first element of urlfetch "https://catfact.ninja/fact")
+            set {_catfact} to valueFromJson({_json}, "fact")
+            if {_catfact} ends with ".":
+                set {_catfact} to (subtext of {_catfact} from character 1 to ((length of {_catfact})-1))
+            send " &d🐈 Cat Fact: &f%{_catfact}% :3"

--- a/scripts/customItems/items/chorium_elytra.sk
+++ b/scripts/customItems/items/chorium_elytra.sk
@@ -29,12 +29,11 @@ on toggle gliding:
         set {_rightwing} to (location 1.25 blocks right of {_loc})
         make 1 of witch at {_leftwing} with extra 0 with force
         make 1 of witch at {_rightwing} with extra 0 with force
-        set {_e::*} to (entities in radius 2.5 of player)
+        set {_e::*} to (entities in radius 2.5 of (location 0.5 blocks under player))
         set {_e::*} to ({_e::*} where [input isn't player])
         set {_source} to (damage source of player_attack caused by player directly by player at player)
         damage {_e::*} by (3.5*{_speed}) with {_source}
         loop {_e::*}:
-            set {_kb} to ({_speed}*(1-(knockback resistance attribute of loop-value)))
-            push loop-value (player's velocity) with force {_kb}
+            push loop-value (player's velocity) with force (1-(knockback resistance attribute of loop-value))
             if loop-value is ("end crystal" parsed as entity type):
                 make player attack loop-value


### PR DESCRIPTION
- Re-add /catfact, now only shows to the person who ran the command
- Add simple json parsing for /catfact
- Chorium elytra hitbox is .5 blocks lower, and hit velocity is changed to no longer be based on player momentum