### PR TITLE
Features to block portals, remove dragonDefeated var

### DIFF
--- a/config.sk
+++ b/config.sk
@@ -394,7 +394,7 @@ databases:
 		
 		# ==== Settings that should not be changed ====
 		
-version: 2.10.1
+version: 2.10.2
 # DO NOT CHANGE THIS VALUE MANUALLY!
 # This saves for which version of Skript this configuration was written for.
 # If it does not match the version of the .jar file then the config will be updated automatically.

--- a/scripts/tweaks/entities/dragon.sk
+++ b/scripts/tweaks/entities/dragon.sk
@@ -5,10 +5,10 @@ on target:
     cancel event
 
 on death of ender dragon:
-    set {dragonDefeated} to true
     set {_disc} to getItem("turtle:music_disc_milky_ways")
     drop 1 of {_disc} at victim
     protectItem(last dropped item)
 
 on load:
-    set {dragonDefeated} to {dragonDefeated} ? false
+    # delete old var
+    delete {dragonDefeated}

--- a/scripts/tweaks/environment/portals.sk
+++ b/scripts/tweaks/environment/portals.sk
@@ -1,0 +1,24 @@
+
+on load:
+    set {-features::disablenether::name} to "Disable nether portals"
+    set {-features::disablenether::desc} to "Stops everything from going to the nether using portals"
+    set {-features::disablenether::icon} to crying obsidian
+    set {-features::disableend::name} to "Disable end portals"
+    set {-features::disableend::desc} to "Stops everything from going to the end using portals"
+    set {-features::disableend::icon} to end portal frame
+
+on player portal:
+    if environment of (world of event-location) is nether:
+        {enabledFeatures::disablenether} is true
+        cancel event
+    if environment of (world of event-location) is end:
+        {enabledFeatures::disableend} is true
+        cancel event
+
+on entity portal:
+    if environment of (world of event-location) is nether:
+        {enabledFeatures::disablenether} is true
+        cancel event
+    if environment of (world of event-location) is end:
+        {enabledFeatures::disableend} is true
+        cancel event

--- a/scripts/tweaks/environment/voidwrap.sk
+++ b/scripts/tweaks/environment/voidwrap.sk
@@ -35,7 +35,7 @@ on damage:
 
 on player tick:
     (y-coord of player) > ({@upWrapY}+5)
-    {dragonDefeated} is true
+    (world {@endWorld}).getEnderDragonBattle().hasBeenPreviouslyKilled() is true
     (world of player) is {@overworld}
     warp(player, {@endWorld}, -59)
     while (y-coord of player) < -49:


### PR DESCRIPTION
- A feature to block portals traveling to nether
- A feature to block portals traveling to end
- Instead of dragonDefeated variable, directly check state of dragon battle in end world