### PR TITLE
Improve game events, voidwrap loads chunks

### DIFF
--- a/scripts/_utils/nms/gameEvents.sk
+++ b/scripts/_utils/nms/gameEvents.sk
@@ -1,36 +1,43 @@
 
 import:
-    net.minecraft.network.protocol.game.ClientboundLevelEventPacket
     net.minecraft.core.BlockPos
 
-# Send game event packets to players
+# Send game events to players
 # https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol#World_Event
 effect:
     patterns:
-        (send|play) (game|level)[ ]event %integer% at %block% [with [[extra ]data] %number%] [to %players%]
+        (send|play) (game|level)[ ]event %integer% at %block% [with [[extra ]data] %-number%]
     trigger:
         set {_event} to expr-1
         set {_block} to expr-2
         set {_data} to expr-3 ? 0
-        set {_players::*} to expr-4 ? (all players in world of {_block})
-        set {_packet} to (new ClientboundLevelEventPacket({_event}, new BlockPos(floor(x-coord of {_block}),floor(y-coord of {_block}),floor(z-coord of {_block})), {_data}, false))
-        transform {_players::*} using input.getHandle().connection.send({_packet})
+        (world of {_block}).getHandle().levelEvent({_event}, new BlockPos(floor(x-coord of {_block}),floor(y-coord of {_block}),floor(z-coord of {_block})), {_data})
 
 # Use this for entity statuses:
 # https://skripthub.net/docs/?id=10516
 
-function dispenserSmoke(block:block):
-    set {_facing} to facing of {_block}
+function getBlockGameEventDir(facing:direction) :: integer:
     if {_facing} is below:
-        set {_data} to 0
+        return 0
     else if {_facing} is above:
-        set {_data} to 1
+        return 1
     else if {_facing} is north:
-        set {_data} to 2
+        return 2
     else if {_facing} is south:
-        set {_data} to 3
+        return 3
     else if {_facing} is west:
-        set {_data} to 4
+        return 4
     else if {_facing} is east:
-        set {_data} to 5
-    play game event (2000) at ({_block}) with data ({_data}) to (all players in (world of {_block}))
+        return 5
+
+function dispenserEvent(block:block):
+    {_block} is a dispenser
+    set {_data} to getBlockGameEventDir(facing of {_block})
+    play game event 1000 at {_block} with data {_data}
+    play game event 2000 at {_block} with data {_data}
+
+function dispenserEventFail(block:block):
+    {_block} is a dispenser
+    set {_data} to getBlockGameEventDir(facing of {_block})
+    play game event 1001 at {_block} with data {_data}
+    play game event 2000 at {_block} with data {_data}

--- a/scripts/chat/commands/catfact.sk
+++ b/scripts/chat/commands/catfact.sk
@@ -1,11 +1,4 @@
 
-import:
-    java.lang.StringBuffer
-    java.io.InputStreamReader
-    java.io.BufferedReader
-    java.net.URL
-    java.net.HttpURLConnection
-
 command /catfact:
     trigger:
         async run 0 ticks later:

--- a/scripts/tweaks/entities/breed.sk
+++ b/scripts/tweaks/entities/breed.sk
@@ -15,12 +15,12 @@ on BlockPreDispenseEvent:
     set {_e::*} to {_e::*} where [input can breed]
     set {_e::*} to {_e::*} where [love time of input is 0 seconds]
     set {_e} to first element of {_e::*}
-    dispenserSmoke({_block})
-    if {_e} isn't set:
-        play sound "minecraft:block.dispenser.fail" in block category with pitch 1.2 at {_block}
+    if {_e} is set:
+        dispenserEvent({_block})
+    else:
+        dispenserEventFail({_block})
         exit trigger
     # set love mode, remove item
     remove 1 of event.getItemStack() from (slot event.getSlot() of inventory of {_block})
-    play sound "minecraft:block.dispenser.dispense" at {_block}
     set love time of {_e} to 30 seconds
     play entity effect love_hearts on {_e}

--- a/scripts/tweaks/environment/voidwrap.sk
+++ b/scripts/tweaks/environment/voidwrap.sk
@@ -1,4 +1,7 @@
 
+import:
+    net.minecraft.core.BlockPos
+
 options:
     overworld: "world"
     endWorld: "world_the_end"
@@ -14,6 +17,7 @@ local function warp(e:entity, world:text, coord:number):
     play sound "minecraft:entity.player.teleport" with volume 0.5 and pitch 2 at {_loc}
     make 15 of witch at {_loc} with force
     relative tp {_e} to {_dest}
+    {_e}.getHandle().placePortalTicket(new BlockPos(floor(x-coord of {_e}),floor(y-coord of {_e}),floor(z-coord of {_e})))
     play sound "minecraft:entity.player.teleport" with volume 0.5 and pitch 2 at {_dest}
     make 15 of witch at {_dest} with force
 

--- a/scripts/tweaks/items/bonemeal.sk
+++ b/scripts/tweaks/items/bonemeal.sk
@@ -25,8 +25,7 @@ local function playerBonemeal(p:player):
 local function dispenserBonemeal(event:object):
     {_event}.setCancelled(true)
     remove 1 bone meal from (slot {_event}.getSlot() of inventory of {_event}.getBlock())
-    play sound "minecraft:block.dispenser.dispense" in block category at {_event}.getBlock()
-    dispenserSmoke({_event}.getBlock())
+    dispenserEvent({_event}.getBlock())
 
 # handle each type of block
 


### PR DESCRIPTION
- Game events use %world%.levelEvent() instead of packets
- Better functions for dispenser game events
- Void wrap creates chunk load tickets same way as vanilla portals