### PR TITLE
Add custom potions

### DIFF
--- a/scripts/customItems/items/potions.sk
+++ b/scripts/customItems/items/potions.sk
@@ -1,0 +1,149 @@
+
+options:
+    # vanilla brew time: 400t (20s)
+    newBrewTime: 200
+
+# Shorter brew time
+import:
+    org.bukkit.event.block.BrewingStartEvent
+on BrewingStartEvent:
+    # faster brew time
+    set {_brewTime} to {@newBrewTime}
+
+    # disable certain recipes
+    if event.getSource() is turtle helmet:
+        set {_brewTime} to 2147483647
+
+    event.setRecipeBrewTime({_brewTime})
+    event.setBrewingTime({_brewTime})
+    
+# It is assumed all potions are defined like so, where 'namespace'
+# is your namespace and 'effect' is the effect id:
+#  namespace:effect_potion
+#  namespace:long_effect_potion
+#  namespace:strong_splash_effect_potion
+#  namespace:lingering_effect_potion
+# etc.
+
+when ready to load recipes:
+    # turtle master
+    addVanillaStartMix("minecraft", "turtle_master", getItem(turtle scute))
+    # haste
+    addStartMix("turtle", "haste", getItem(armadillo scute))
+    addConversionMixes("turtle", "haste")
+    addUpgradeMixes("turtle", "haste")
+    # mining fatigue
+    addCorruptMixes("turtle", "mining_fatigue", "haste")
+    addConversionMixes("turtle", "mining_fatigue")
+    addUpgradeMixes("turtle", "mining_fatigue")
+    # levitation
+    addCorruptMixesFromVanilla("turtle", "levitation", "slow_falling", true, false)
+    addConversionMixes("turtle", "levitation")
+    addUpgradeMixes("turtle", "levitation")
+    # blindness
+    addCorruptMixesFromVanilla("turtle", "blindness", "night_vision", true, false)
+    addConversionMixes("turtle", "blindness", true, false)
+    addUpgradeMixes("turtle", "blindness", true, false)
+    # glowing
+    addStartMix("turtle", "glowing", getItem(glowstone block))
+    addConversionMixes("turtle", "glowing", true, false)
+    addUpgradeMixes("turtle", "glowing", true, false)
+    # invis
+    addCorruptMixesToVanilla("turtle", "glowing", "invisibility", true, false)
+    # wither
+    addStartMix("turtle", "wither", getItem(wither rose))
+    addConversionMixes("turtle", "wither")
+    addUpgradeMixes("turtle", "wither")
+
+# Potion functions
+local function addMix(id:string, input:item, ingredient:item, result:item):
+    register brewing recipe:
+        id: {_id}
+        input: {_input}
+        ingredient: {_ingredient}
+        result: {_result}
+
+local function addStartMix(namespace:string, effect:string, ingredient:item):
+    addMix("%{_namespace}%:mundane_potion_from_%{_effect}%", getItem(water bottle), {_ingredient}, getItem(mundane potion))
+    addMix("%{_namespace}%:%{_effect}%_potion_start", getItem(awkward potion), {_ingredient}, getItem("%{_namespace}%:%{_effect}%_potion"))
+    addMix("%{_namespace}%:splash_%{_effect}%_potion_start", getItem(awkward splash potion), {_ingredient}, getItem("%{_namespace}%:splash_%{_effect}%_potion"))
+    addMix("%{_namespace}%:lingering_%{_effect}%_potion_start", getItem(awkward lingering potion), {_ingredient}, getItem("%{_namespace}%:lingering_%{_effect}%_potion"))
+
+local function addVanillaStartMix(namespace:string, effect:string, ingredient:item):
+    set {_effect_nbt} to "{""minecraft:potion_contents"":{potion:""minecraft:%{_effect}%""}}"
+    addMix("%{_namespace}%:mundane_potion_from_%{_effect}%", getItem(water bottle), {_ingredient}, getItem(mundane potion))
+    addMix("%{_namespace}%:%{_effect}%_potion_start", getItem(awkward potion), {_ingredient}, getItem(potion with nbt from {_effect_nbt}))
+    addMix("%{_namespace}%:splash_%{_effect}%_potion_start", getItem(awkward splash potion), {_ingredient}, getItem(splash potion with nbt from {_effect_nbt}))
+    addMix("%{_namespace}%:lingering_%{_effect}%_potion_start", getItem(awkward lingering potion), {_ingredient}, getItem(lingering potion with nbt from {_effect_nbt}))
+
+local function addCorruptMixes(namespace:string, effect:string, fromeffect:string, long:boolean=true, strong:boolean=true):
+    set {_spidereye} to getItem(fermented spider eye)
+    addMix("%{_namespace}%:%{_effect}%_potion_corrupt", getItem("%{_namespace}%:%{_fromeffect}%_potion"), {_spidereye}, getItem("%{_namespace}%:%{_effect}%_potion"))
+    addMix("%{_namespace}%:splash_%{_effect}%_potion_corrupt", getItem("%{_namespace}%:splash_%{_fromeffect}%_potion"), {_spidereye}, getItem("%{_namespace}%:splash_%{_effect}%_potion"))
+    addMix("%{_namespace}%:lingering_%{_effect}%_potion_corrupt", getItem("%{_namespace}%:lingering_%{_fromeffect}%_potion"), {_spidereye}, getItem("%{_namespace}%:lingering_%{_effect}%_potion"))
+    if {_long} is true:
+        addMix("%{_namespace}%:long_%{_effect}%_potion_corrupt", getItem("%{_namespace}%:long_%{_fromeffect}%_potion"), {_spidereye}, getItem("%{_namespace}%:long_%{_effect}%_potion"))
+        addMix("%{_namespace}%:long_splash_%{_effect}%_potion_corrupt", getItem("%{_namespace}%:long_splash_%{_fromeffect}%_potion"), {_spidereye}, getItem("%{_namespace}%:long_splash_%{_effect}%_potion"))
+        addMix("%{_namespace}%:long_lingering_%{_effect}%_potion_corrupt", getItem("%{_namespace}%:long_lingering_%{_fromeffect}%_potion"), {_spidereye}, getItem("%{_namespace}%:long_lingering_%{_effect}%_potion"))
+    if {_strong} is true:
+        addMix("%{_namespace}%:strong_%{_effect}%_potion_corrupt", getItem("%{_namespace}%:strong_%{_fromeffect}%_potion"), {_spidereye}, getItem("%{_namespace}%:strong_%{_effect}%_potion"))
+        addMix("%{_namespace}%:strong_splash_%{_effect}%_potion_corrupt", getItem("%{_namespace}%:strong_splash_%{_fromeffect}%_potion"), {_spidereye}, getItem("%{_namespace}%:strong_splash_%{_effect}%_potion"))
+        addMix("%{_namespace}%:strong_lingering_%{_effect}%_potion_corrupt", getItem("%{_namespace}%:strong_lingering_%{_fromeffect}%_potion"), {_spidereye}, getItem("%{_namespace}%:strong_lingering_%{_effect}%_potion"))
+
+local function addCorruptMixesFromVanilla(namespace:string, effect:string, fromeffect:string, long:boolean=true, strong:boolean=true):
+    set {_spidereye} to getItem(fermented spider eye)
+    set {_from_nbt_normal} to "{""minecraft:potion_contents"":{potion:""minecraft:%{_fromeffect}%""}}"
+    set {_from_nbt_long} to "{""minecraft:potion_contents"":{potion:""minecraft:long_%{_fromeffect}%""}}"
+    set {_from_nbt_strong} to "{""minecraft:potion_contents"":{potion:""minecraft:strong_%{_fromeffect}%""}}"
+    addMix("%{_namespace}%:%{_effect}%_potion_corrupt", getItem(potion with nbt from {_from_nbt_normal}), {_spidereye}, getItem("%{_namespace}%:%{_effect}%_potion"))
+    addMix("%{_namespace}%:splash_%{_effect}%_potion_corrupt", getItem(splash potion with nbt from {_from_nbt_normal}), {_spidereye}, getItem("%{_namespace}%:splash_%{_effect}%_potion"))
+    addMix("%{_namespace}%:lingering_%{_effect}%_potion_corrupt", getItem(lingering potion with nbt from {_from_nbt_normal}), {_spidereye}, getItem("%{_namespace}%:lingering_%{_effect}%_potion"))
+    if {_long} is true:
+        addMix("%{_namespace}%:long_%{_effect}%_potion_corrupt", getItem(potion with nbt from {_from_nbt_long}), {_spidereye}, getItem("%{_namespace}%:long_%{_effect}%_potion"))
+        addMix("%{_namespace}%:long_splash_%{_effect}%_potion_corrupt", getItem(splash potion with nbt from {_from_nbt_long}), {_spidereye}, getItem("%{_namespace}%:long_splash_%{_effect}%_potion"))
+        addMix("%{_namespace}%:long_lingering_%{_effect}%_potion_corrupt", getItem(lingering potion with nbt from {_from_nbt_long}), {_spidereye}, getItem("%{_namespace}%:long_lingering_%{_effect}%_potion"))
+    if {_strong} is true:
+        addMix("%{_namespace}%:strong_%{_effect}%_potion_corrupt", getItem(potion with nbt from {_from_nbt_strong}), {_spidereye}, getItem("%{_namespace}%:strong_%{_effect}%_potion"))
+        addMix("%{_namespace}%:strong_splash_%{_effect}%_potion_corrupt", getItem(splash potion with nbt from {_from_nbt_strong}), {_spidereye}, getItem("%{_namespace}%:strong_splash_%{_effect}%_potion"))
+        addMix("%{_namespace}%:strong_lingering_%{_effect}%_potion_corrupt", getItem(lingering potion with nbt from {_from_nbt_strong}), {_spidereye}, getItem("%{_namespace}%:strong_lingering_%{_effect}%_potion"))
+
+local function addCorruptMixesToVanilla(namespace:string, effect:string, toeffect:string, long:boolean=true, strong:boolean=true):
+    set {_spidereye} to getItem(fermented spider eye)
+    set {_to_nbt_normal} to "{""minecraft:potion_contents"":{potion:""minecraft:%{_toeffect}%""}}"
+    set {_to_nbt_long} to "{""minecraft:potion_contents"":{potion:""minecraft:long_%{_toeffect}%""}}"
+    set {_to_nbt_strong} to "{""minecraft:potion_contents"":{potion:""minecraft:strong_%{_toeffect}%""}}"
+    addMix("minecraft:%{_toeffect}%_potion_corrupt", getItem("%{_namespace}%:%{_effect}%_potion"), {_spidereye}, getItem(potion with nbt from {_to_nbt_normal}))
+    addMix("minecraft:splash_%{_toeffect}%_potion_corrupt", getItem("%{_namespace}%:splash_%{_effect}%_potion"), {_spidereye}, getItem(splash potion with nbt from {_to_nbt_normal}))
+    addMix("minecraft:lingering_%{_toeffect}%_potion_corrupt", getItem("%{_namespace}%:lingering_%{_effect}%_potion"), {_spidereye}, getItem(lingering potion with nbt from {_to_nbt_normal}))
+    if {_long} is true:
+        addMix("minecraft:long_%{_toeffect}%_potion_corrupt", getItem("%{_namespace}%:long_%{_effect}%_potion"), {_spidereye}, getItem(potion with nbt from {_to_nbt_long}))
+        addMix("minecraft:long_splash_%{_toeffect}%_potion_corrupt", getItem("%{_namespace}%:long_splash_%{_effect}%_potion"), {_spidereye}, getItem(splash potion with nbt from {_to_nbt_long}))
+        addMix("minecraft:long_lingering_%{_toeffect}%_potion_corrupt", getItem("%{_namespace}%:long_lingering_%{_effect}%_potion"), {_spidereye}, getItem(lingering potion with nbt from {_to_nbt_long}))
+    if {_strong} is true:
+        addMix("minecraft:strong_%{_toeffect}%_potion_corrupt", getItem("%{_namespace}%:strong_%{_effect}%_potion"), {_spidereye}, getItem(potion with nbt from {_to_nbt_strong}))
+        addMix("minecraft:strong_splash_%{_toeffect}%_potion_corrupt", getItem("%{_namespace}%:strong_splash_%{_effect}%_potion"), {_spidereye}, getItem(splash potion with nbt from {_to_nbt_strong}))
+        addMix("minecraft:strong_lingering_%{_toeffect}%_potion_corrupt", getItem("%{_namespace}%:strong_lingering_%{_effect}%_potion"), {_spidereye}, getItem(lingering potion with nbt from {_to_nbt_strong}))
+
+local function addConversionMixes(namespace:string, effect:string, long:boolean=true, strong:boolean=true):
+    set {_gunpowder} to getItem(gunpowder)
+    set {_dragonbreath} to getItem(dragon breath)
+    addMix("%{_namespace}%:splash_%{_effect}%_potion", getItem("%{_namespace}%:%{_effect}%_potion"), {_gunpowder}, getItem("%{_namespace}%:splash_%{_effect}%_potion"))
+    addMix("%{_namespace}%:lingering_%{_effect}%_potion", getItem("%{_namespace}%:splash_%{_effect}%_potion"), {_dragonbreath}, getItem("%{_namespace}%:lingering_%{_effect}%_potion"))
+    if {_long} is true:
+        addMix("%{_namespace}%:long_splash_%{_effect}%_potion", getItem("%{_namespace}%:long_%{_effect}%_potion"), {_gunpowder}, getItem("%{_namespace}%:long_splash_%{_effect}%_potion"))
+        addMix("%{_namespace}%:long_lingering_%{_effect}%_potion", getItem("%{_namespace}%:long_splash_%{_effect}%_potion"), {_dragonbreath}, getItem("%{_namespace}%:long_lingering_%{_effect}%_potion"))
+    if {_strong} is true:
+        addMix("%{_namespace}%:strong_splash_%{_effect}%_potion", getItem("%{_namespace}%:strong_%{_effect}%_potion"), {_gunpowder}, getItem("%{_namespace}%:strong_splash_%{_effect}%_potion"))
+        addMix("%{_namespace}%:strong_lingering_%{_effect}%_potion", getItem("%{_namespace}%:strong_splash_%{_effect}%_potion"), {_dragonbreath}, getItem("%{_namespace}%:strong_lingering_%{_effect}%_potion"))
+
+local function addUpgradeMixes(namespace:string, effect:string, long:boolean=true, strong:boolean=true):
+    set {_redstone} to getItem(redstone)
+    set {_glowstone} to getItem(glowstone dust)
+    if {_long} is true:
+        addMix("%{_namespace}%:long_%{_effect}%_potion_upgrade", getItem("%{_namespace}%:%{_effect}%_potion"), {_redstone}, getItem("%{_namespace}%:long_%{_effect}%_potion"))
+        addMix("%{_namespace}%:long_splash_%{_effect}%_potion_upgrade", getItem("%{_namespace}%:splash_%{_effect}%_potion"), {_redstone}, getItem("%{_namespace}%:long_splash_%{_effect}%_potion"))
+        addMix("%{_namespace}%:long_lingering_%{_effect}%_potion_upgrade", getItem("%{_namespace}%:lingering_%{_effect}%_potion"), {_redstone}, getItem("%{_namespace}%:long_lingering_%{_effect}%_potion"))
+    if {_strong} is true:
+        addMix("%{_namespace}%:strong_%{_effect}%_potion_upgrade", getItem("%{_namespace}%:%{_effect}%_potion"), {_glowstone}, getItem("%{_namespace}%:strong_%{_effect}%_potion"))
+        addMix("%{_namespace}%:strong_splash_%{_effect}%_potion_upgrade", getItem("%{_namespace}%:splash_%{_effect}%_potion"), {_glowstone}, getItem("%{_namespace}%:strong_splash_%{_effect}%_potion"))
+        addMix("%{_namespace}%:strong_lingering_%{_effect}%_potion_upgrade", getItem("%{_namespace}%:lingering_%{_effect}%_potion"), {_glowstone}, getItem("%{_namespace}%:strong_lingering_%{_effect}%_potion"))

--- a/scripts/customItems/yamls/potions.yml
+++ b/scripts/customItems/yamls/potions.yml
@@ -1,0 +1,460 @@
+minecraft:
+  items:
+    potion:
+      max_stack_size: 16
+turtle:
+  items:
+    # Haste
+    haste_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#D9C043"
+        custom_name: "haste"
+        custom_effects:
+          minecraft:haste:
+            amplifier: 1
+            duration: 180
+    long_haste_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#D9C043"
+        custom_name: "haste"
+        custom_effects:
+          minecraft:haste:
+            amplifier: 1
+            duration: 480
+    strong_haste_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#D9C043"
+        custom_name: "haste"
+        custom_effects:
+          minecraft:haste:
+            amplifier: 2
+            duration: 90
+    splash_haste_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#D9C043"
+        custom_name: "haste"
+        custom_effects:
+          minecraft:haste:
+            amplifier: 1
+            duration: 180
+    long_splash_haste_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#D9C043"
+        custom_name: "haste"
+        custom_effects:
+          minecraft:haste:
+            amplifier: 1
+            duration: 480
+    strong_splash_haste_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#D9C043"
+        custom_name: "haste"
+        custom_effects:
+          minecraft:haste:
+            amplifier: 2
+            duration: 90
+    lingering_haste_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#D9C043"
+        custom_name: "haste"
+        custom_effects:
+          minecraft:haste:
+            amplifier: 1
+            duration: 45
+    long_lingering_haste_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#D9C043"
+        custom_name: "haste"
+        custom_effects:
+          minecraft:haste:
+            amplifier: 1
+            duration: 120
+    strong_lingering_haste_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#D9C043"
+        custom_name: "haste"
+        custom_effects:
+          minecraft:haste:
+            amplifier: 2
+            duration: 22
+    # Mining Fatigue
+    mining_fatigue_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#4A4217"
+        custom_name: "mining_fatigue"
+        custom_effects:
+          minecraft:mining_fatigue:
+            amplifier: 1
+            duration: 90
+    long_mining_fatigue_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#4A4217"
+        custom_name: "mining_fatigue"
+        custom_effects:
+          minecraft:mining_fatigue:
+            amplifier: 1
+            duration: 240
+    strong_mining_fatigue_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#4A4217"
+        custom_name: "mining_fatigue"
+        custom_effects:
+          minecraft:mining_fatigue:
+            amplifier: 4
+            duration: 20
+    splash_mining_fatigue_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#4A4217"
+        custom_name: "mining_fatigue"
+        custom_effects:
+          minecraft:mining_fatigue:
+            amplifier: 1
+            duration: 90
+    long_splash_mining_fatigue_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#4A4217"
+        custom_name: "mining_fatigue"
+        custom_effects:
+          minecraft:mining_fatigue:
+            amplifier: 1
+            duration: 240
+    strong_splash_mining_fatigue_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#4A4217"
+        custom_name: "mining_fatigue"
+        custom_effects:
+          minecraft:mining_fatigue:
+            amplifier: 4
+            duration: 20
+    lingering_mining_fatigue_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#4A4217"
+        custom_name: "mining_fatigue"
+        custom_effects:
+          minecraft:mining_fatigue:
+            amplifier: 1
+            duration: 22
+    long_lingering_mining_fatigue_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#4A4217"
+        custom_name: "mining_fatigue"
+        custom_effects:
+          minecraft:mining_fatigue:
+            amplifier: 1
+            duration: 60
+    strong_lingering_mining_fatigue_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#4A4217"
+        custom_name: "mining_fatigue"
+        custom_effects:
+          minecraft:mining_fatigue:
+            amplifier: 4
+            duration: 5
+    # Levitation
+    levitation_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#CEFFFF"
+        custom_name: "levitation"
+        custom_effects:
+          minecraft:levitation:
+            amplifier: 1
+            duration: 20
+    long_levitation_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#CEFFFF"
+        custom_name: "levitation"
+        custom_effects:
+          minecraft:levitation:
+            amplifier: 1
+            duration: 40
+    strong_levitation_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#CEFFFF"
+        custom_name: "levitation"
+        custom_effects:
+          minecraft:levitation:
+            amplifier: 2
+            duration: 20
+    splash_levitation_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#CEFFFF"
+        custom_name: "levitation"
+        custom_effects:
+          minecraft:levitation:
+            amplifier: 1
+            duration: 20
+    long_splash_levitation_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#CEFFFF"
+        custom_name: "levitation"
+        custom_effects:
+          minecraft:levitation:
+            amplifier: 1
+            duration: 40
+    strong_splash_levitation_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#CEFFFF"
+        custom_name: "levitation"
+        custom_effects:
+          minecraft:levitation:
+            amplifier: 2
+            duration: 20
+    lingering_levitation_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#CEFFFF"
+        custom_name: "levitation"
+        custom_effects:
+          minecraft:levitation:
+            amplifier: 1
+            duration: 5
+    long_lingering_levitation_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#CEFFFF"
+        custom_name: "levitation"
+        custom_effects:
+          minecraft:levitation:
+            amplifier: 1
+            duration: 10
+    strong_lingering_levitation_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#CEFFFF"
+        custom_name: "levitation"
+        custom_effects:
+          minecraft:levitation:
+            amplifier: 2
+            duration: 5
+    # Blindness
+    blindness_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#1F1F23"
+        custom_name: "blindness"
+        custom_effects:
+          minecraft:blindness:
+            amplifier: 1
+            duration: 90
+    long_blindness_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#1F1F23"
+        custom_name: "blindness"
+        custom_effects:
+          minecraft:blindness:
+            amplifier: 1
+            duration: 240
+    splash_blindness_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#1F1F23"
+        custom_name: "blindness"
+        custom_effects:
+          minecraft:blindness:
+            amplifier: 1
+            duration: 90
+    long_splash_blindness_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#1F1F23"
+        custom_name: "blindness"
+        custom_effects:
+          minecraft:blindness:
+            amplifier: 1
+            duration: 240
+    lingering_blindness_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#1F1F23"
+        custom_name: "blindness"
+        custom_effects:
+          minecraft:blindness:
+            amplifier: 1
+            duration: 22
+    long_lingering_blindness_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#1F1F23"
+        custom_name: "blindness"
+        custom_effects:
+          minecraft:blindness:
+            amplifier: 1
+            duration: 60
+    # Glowing
+    glowing_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#94A061"
+        custom_name: "glowing"
+        custom_effects:
+          minecraft:glowing:
+            amplifier: 1
+            duration: 90
+    long_glowing_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#94A061"
+        custom_name: "glowing"
+        custom_effects:
+          minecraft:glowing:
+            amplifier: 1
+            duration: 240
+    splash_glowing_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#94A061"
+        custom_name: "glowing"
+        custom_effects:
+          minecraft:glowing:
+            amplifier: 1
+            duration: 90
+    long_splash_glowing_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#94A061"
+        custom_name: "glowing"
+        custom_effects:
+          minecraft:glowing:
+            amplifier: 1
+            duration: 240
+    lingering_glowing_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#94A061"
+        custom_name: "glowing"
+        custom_effects:
+          minecraft:glowing:
+            amplifier: 1
+            duration: 22
+    long_lingering_glowing_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#94A061"
+        custom_name: "glowing"
+        custom_effects:
+          minecraft:glowing:
+            amplifier: 1
+            duration: 60
+    # Wither
+    wither_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#736156"
+        custom_name: "wither"
+        custom_effects:
+          minecraft:wither:
+            amplifier: 1
+            duration: 90
+    long_wither_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#736156"
+        custom_name: "wither"
+        custom_effects:
+          minecraft:wither:
+            amplifier: 1
+            duration: 240
+    strong_wither_potion:
+      base: potion
+      max_stack_size: 16
+      potion_contents:
+        custom_color: "#736156"
+        custom_name: "wither"
+        custom_effects:
+          minecraft:wither:
+            amplifier: 4
+            duration: 20
+    splash_wither_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#736156"
+        custom_name: "wither"
+        custom_effects:
+          minecraft:wither:
+            amplifier: 1
+            duration: 90
+    long_splash_wither_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#736156"
+        custom_name: "wither"
+        custom_effects:
+          minecraft:wither:
+            amplifier: 1
+            duration: 240
+    strong_splash_wither_potion:
+      base: splash_potion
+      potion_contents:
+        custom_color: "#736156"
+        custom_name: "wither"
+        custom_effects:
+          minecraft:wither:
+            amplifier: 4
+            duration: 20
+    lingering_wither_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#736156"
+        custom_name: "wither"
+        custom_effects:
+          minecraft:wither:
+            amplifier: 1
+            duration: 22
+    long_lingering_wither_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#736156"
+        custom_name: "wither"
+        custom_effects:
+          minecraft:wither:
+            amplifier: 1
+            duration: 60
+    strong_lingering_wither_potion:
+      base: lingering_potion
+      potion_contents:
+        custom_color: "#736156"
+        custom_name: "wither"
+        custom_effects:
+          minecraft:wither:
+            amplifier: 4
+            duration: 5


### PR DESCRIPTION
### Vanilla Brewing Changes
- Brewing takes 10s instead of 20s
- Turtle master potion is made with turtle scute instead of turtle helmet
- Invisibility potion is made by corrupting glowing (instead of night vision)
### New Potions
- Haste potion, brewed with armadillo scute
- Mining fatigue potion, made by corrupting haste potion
- Levitation potion, made by corrupting slow falling potion
- Blindness potion, made by corrupting night vision potion
- Glowing potion, brewed with glowstone block
- Decay (wither) potion, brewed with wither rose

- Entire system to register these potions via similar functions to minecraft's method