### PR TITLE
Fix impaling damage & fix anvil italic item names

### DIFF
--- a/scripts/blocks/anvil.sk
+++ b/scripts/blocks/anvil.sk
@@ -2,10 +2,11 @@
 on anvil prepare:
     # no cost stacking
     if getConfigValue("root.world.enchanting.anvil.noCostStacking") is true:
-        reset repair cost component of event-item
+        reset (repair cost component of event-item)
     # colored rename
     if getConfigValue("root.world.enchanting.anvil.coloredRename") is true:
-        set event-slot's name to (colored event-item's name)
+        event-slot's name is set
+        set (event-slot's name) to (formatted "<!i>%event-item's name%")
     # free renames
     if getConfigValue("root.world.enchanting.anvil.freeRenames") is true:
         if name of (slot 2 of event-inventory) isn't set:

--- a/scripts/items/vanilla/trident.sk
+++ b/scripts/items/vanilla/trident.sk
@@ -6,13 +6,26 @@ on damage:
     # check impaling
     victim is wet
     set {_direct} to (direct entity)
-    set {_weapon} to (({_direct}'s tool) ? (item of {_direct}))
-    if ({_direct} is riptiding):
-        set {_weapon} to ({-playerData::%{_direct}%::riptideitem} ? {_weapon})
+    {_direct} is a trident
+    set {_weapon} to (item of {_direct})
     set {_lvl} to (level of impaling of {_weapon})
     {_lvl} is set
     # add damage
+    add ({_lvl}*2) to damage
+
+on any damage:
+    {-playerData::%direct entity%::impalingBonusDamage} is set
+    add {-playerData::%direct entity%::impalingBonusDamage} to damage
+    delete {-playerData::%direct entity%::impalingBonusDamage}
+
+on attack attempt:
+    event.willAttack() is true
+    victim is wet
+    set {_weapon} to (player's tool)
+    set {_weapon} to ({-playerData::%{_direct}%::riptideitem} ? {_weapon}) if (player is riptiding)
+    set {_lvl} to (level of impaling of {_weapon})
+    {_lvl} is set
     set {_added} to ({_lvl}*2)
-    set {_cooldown} to (({_direct}'s attack cooldown) ? 1)^2
+    set {_cooldown} to (player's attack cooldown)^2
     set {_added} to ({_added} * {_cooldown})
-    add {_added} to damage
+    set {-playerData::%player%::impalingBonusDamage} to {_added}


### PR DESCRIPTION
- Impaling now adds the correct amount of bonus damage
- Item names when being renamed in an anvil are no longer italic by default