### PR TITLE
Name tag editing, better custom lore

### DIFF
--- a/scripts/_utils/utils/minimessage.sk
+++ b/scripts/_utils/utils/minimessage.sk
@@ -1,0 +1,11 @@
+
+function getLoreText(text:string) :: text components:
+    set {_loreColor} to getConfigValue("root.server.colors.loreColor")
+    set {_loreAccentColor} to getConfigValue("root.server.colors.loreAccentColor")
+    set {_text} to "<r>%raw {_text}%"
+    replace "<newline>" with (raw "<br>") in {_text}
+    replace "<br>" in {_text} with (raw "<br><r>")
+    replace "<reset>" with (raw "<r>") in {_text}
+    replace "<r>" with (raw "<r>%raw "<!i>"%%raw {_loreColor}%") in {_text}
+    replace "<accent>" with (raw {_loreAccentColor}) in {_text}
+    return (split (minimessage from {_text}).component at "<br>") mapped using (formatted input)

--- a/scripts/items/custom/chorium_case.sk
+++ b/scripts/items/custom/chorium_case.sk
@@ -29,7 +29,7 @@ local function updateItem(item:item) :: item:
         set (item model of {_item}) to "turtle:chorium_case_filled"
         add custom interact to {_item}
     add "<!i>§d%{_amount}%§5/{@maxAmount}" to {_l::*}
-    add "<!i>§7Capable of storing a large amount of ender pearls" to {_l::*}
+    add getLoreText("Capable of storing a large amount of ender pearls") to {_l::*}
     set (lore of {_item}) to {_l::*}
     return {_item}
 

--- a/scripts/items/custom/chorium_mirror.sk
+++ b/scripts/items/custom/chorium_mirror.sk
@@ -19,7 +19,7 @@ local function updateItem(item:item) :: item:
         add "<!i>§fBound to: §d%floor(x-coord of {_loc})%§5,§d%floor(y-coord of {_loc})%§5,§d%floor(z-coord of {_loc})%§f in §d%world of {_loc}%" to {_l::*}
     else:
         add "<!i>§fUnbound" to {_l::*}
-    add "<!i>§7Save a location and teleport to it from anywhere" to {_l::*}
+    add getLoreText("Save a location and teleport to it from anywhere") to {_l::*}
     set (lore of {_item}) to {_l::*}
     return {_item}
 

--- a/scripts/items/custom/filter.sk
+++ b/scripts/items/custom/filter.sk
@@ -6,19 +6,7 @@ options:
 when ready to register custom items:
     set (custom item "turtle:filter") to (firework star with nbt from "{""minecraft:item_model"":""turtle:filter"",""minecraft:item_name"":""Filter"",""minecraft:max_stack_size"":1}")
     add custom interact to (custom item "turtle:filter")
-    # lore
-    set {_c1::1} to (text component from "§7Use ")
-    set {_c1::2} to (keybind component from "key.use")
-    set (color format of {_c1::2}) to rgb(102,217,217)
-    set {_c1::3} to (text component from "§7 to edit the filter")
-    set (italic format of {_c1::*}) to false
-    
-    set {_c2::1} to (text component from "§7Use ")
-    set {_c2::2} to (keybind component from "key.use")
-    set (color format of {_c2::2}) to rgb(102,217,217)
-    set {_c2::3} to (text component from "§7 on a hopper to apply the filter")
-    set (italic format of {_c2::*}) to false
-    set component lore of (custom item "turtle:filter") to (merge components {_c1::*}) and (merge components {_c2::*})
+    set lore of (custom item "turtle:filter") to getLoreText("Use <accent><key:key.use> <r>to edit the filter<br>Use <accent><key:key.use> on a hopper <r>to apply the filter")
 
 when ready to load recipes:
     register shaped recipe:

--- a/scripts/items/custom/magnifying_glass.sk
+++ b/scripts/items/custom/magnifying_glass.sk
@@ -4,13 +4,7 @@ when ready to register custom items:
     apply use cooldown component to (custom item "turtle:magnifying_glass"):
         seconds: 3 seconds
         group: "turtle:magnifying_glass"
-    # lore
-    set {_c::1} to (text component from "§7Use ")
-    set {_c::2} to (keybind component from "key.use")
-    set (color format of {_c::2}) to rgb(102,217,217)
-    set {_c::3} to (text component from "§7 to display info about blocks and entities")
-    set (italic format of {_c::*}) to false
-    set component lore of (custom item "turtle:magnifying_glass") to (merge components {_c::*})
+    set lore of (custom item "turtle:magnifying_glass") to getLoreText("Use <accent><key:key.use> <r>to display info about blocks and entities")
 
 when ready to load recipes:
     register shaped recipe:

--- a/scripts/items/vanilla/name_tag.sk
+++ b/scripts/items/vanilla/name_tag.sk
@@ -1,0 +1,26 @@
+
+register custom items:
+    set (custom item "minecraft:name_tag") to name tag
+    set (lore of (custom item "minecraft:name_tag")) to getLoreText("Use <accent><key:key.use> <r>to edit name")
+    add custom interact to (custom item "minecraft:name_tag")
+
+on custom interact with "minecraft:name_tag":
+    open anvil inventory to player
+    set {_inv} to (player's top inventory)
+    set {-playerData::%player%::gui} to {_inv}
+    set {-playerData::%player%::guiType} to "name_tag_edit"
+    if event-equipmentslot is main hand:
+        set (slot 0 of {_inv}) to player's tool
+        delete player's tool
+    else:
+        set (slot 0 of {_inv}) to player's offhand tool
+        delete player's offhand tool
+
+on any inventory click:
+    clicked inventory is {-playerData::%player%::gui}
+    {-playerData::%player%::guiType} is "name_tag_edit"
+    (index of clicked slot) isn't 0
+    uncancel event
+    (index of clicked slot) is 2
+    (clicked slot) isn't air
+    play sound "minecraft:ui.cartography_table.take_result" in (ui) at player to player

--- a/scripts/server/config/config.sk
+++ b/scripts/server/config/config.sk
@@ -97,10 +97,17 @@ function setConfigValue(path:string, value:object, changer:commandsender={_}) ::
             return false
     else:
         return false
+    # exit if value is unchanged
     return true if {configValues::%{_path}%} is {_final}
+    if all:
+        getWhetherConfigValueIsDefault({_path}) is true
+        {_final} is getDefaultConfigValue({_path})
+    then:
+        return true
+    # save new value
     set {configValues::%{_path}%} to {_final}
     set {_by} to ("§r by %{_changer}%" if ({_changer} is set) else "")
-    log info "Config element §b%{_path}%§r has been set to §6%{_final}%%{_by}%"
+    log info "Config element §b%{_path}%§r has been set to §6%raw {_final}%%{_by}%"
     return true
 
 function resetConfigValue(path:string, changer:commandsender={_}):

--- a/server_data/config.json
+++ b/server_data/config.json
@@ -109,6 +109,25 @@
             "desc": "Whether debug messages should be visible in console",
             "type": "boolean",
             "default": false
+          },
+          "colors": {
+            "name": "Colors",
+            "desc": "Configure colors used in texts",
+            "item": "minecraft:cyan_dye",
+            "nodes": {
+              "loreColor": {
+                "name": "Lore color",
+                "desc": "Color of plain text in item descriptions, in minimessage format",
+                "type": "text",
+                "default": "<#b0bfce>"
+              },
+              "loreAccentColor": {
+                "name": "Lore accent color",
+                "desc": "Color of accented text in item descriptions, in minimessage format",
+                "type": "text",
+                "default": "<#66d9d9>"
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
- Name tags can be edited without an anvil
- Improve lore text of custom items, and make it easier to write
- Add config values for lore color and lore accent color
- Fix config values saving as not set to default anymore when they are set to default and their config page is saved
- Fix value being formatted in the config element changed message